### PR TITLE
Extended OpenAPi parser with JSON format

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -9,10 +9,23 @@ import sys
 
 import yaml
 
+parsers = {
+    '.yaml': yaml.safe_load,
+    '.json': json.loads,
+}
+
+
+
 
 def load(path):
+    _, extension = os.path.splitext(path)
+    parse = parsers.get(extension)
+
+    if parse is None:
+        raise NotImplementedError('No parser specified for this file type', path)
+
     with open(path) as f:
-        return resolve(yaml.safe_load(f.read()), os.path.dirname(path))
+        return resolve(parse(f.read()), os.path.dirname(path))
 
 
 def resolve(content, dir):


### PR DESCRIPTION
@JacekClearcode New OpenAPI specs use JSON format. We can merge it to the 6.1 branch, but I think it'll be better to have consistent behavior across branches. Still that will require merging changes upstream (to each later version).