### PR TITLE
platform docs fo 15.0.0 + mini fix of json dumper

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -31,6 +31,7 @@ api_definitions = {
     'audience_manager_public_api.json': 'audience_manager/public_api/index.yaml',
     'platform_access_control_authorized_api.json': 'platform/authorized_api/access_control/public_v2.yaml',
     'platform_apps_authorized_api.json': 'platform/authorized_api/apps/public_v2.yaml',
+    'platform_audit_log_authorized_api.json': 'platform/authorized_api/audit_log/public_v1.yaml',
     'platform_meta_sites_authorized_api.json': 'platform/authorized_api/meta_sites/public_v1.yaml',
     'platform_modules_authorized_api.json': 'platform/authorized_api/modules/public_v1.yaml',
     'platform_tracker_settings_authorized_api.json': 'platform/authorized_api/tracker_settings/public_v1.yaml',

--- a/convert.py
+++ b/convert.py
@@ -46,7 +46,7 @@ def write_open_api_json(path, file_handler, version=None):
     if version is not None:
         specs['info']['version'] = version
 
-    file_handler.write(json.dumps(specs))
+    file_handler.write(json.dumps(specs, default=str))
 
 
 if __name__ == '__main__':

--- a/platform/authorized_api/audit_log/audit_log_api.rst
+++ b/platform/authorized_api/audit_log/audit_log_api.rst
@@ -1,0 +1,7 @@
+Audit log API
+====================
+
+.. raw:: html
+
+    <redoc spec-url="../../../_static/api/platform_audit_log_authorized_api.json" expand-responses="" sticky-sidebar="">
+    </redoc>

--- a/platform/authorized_api/audit_log/public_v1.yaml
+++ b/platform/authorized_api/audit_log/public_v1.yaml
@@ -1,0 +1,360 @@
+openapi: 3.0.2
+info:
+  title: Audit Log Api
+  version: auto
+paths:
+  /api/audit-log/v1/entries:
+    get:
+      summary: Entry list
+      description: >
+        List of Audit Log entries<br><br>
+        To specify filters use `?filter[name]=value` syntax (e.g. `?filter[type]=app.added,app.edited`)<br><br>
+        To return csv instead of json, use `Accept: text/csv` header
+      operationId: audit_log_entries_v1
+      parameters:
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+        - $ref: "#/components/parameters/EntriesFilter"
+        - $ref: "#/components/parameters/Sort"
+      responses:
+        200:
+          description: OK
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Entry"
+            text/csv:
+              example: |
+                author_email,author_id,created_at,id,ip,payload,subject_id,type,version
+                john@company.com,378871f1-ec3e-11ea-b4d9-0242ac150002,2020-03-19T21:49:36Z,06768bbe-ec3f-11ea-9ba2-0242ac150002,68.242.57.125,"{""id"": ""06768bbe-ec3f-11ea-9ba2-0242ac150002"", ""urls"": [""http://piwik.pro""]}",06768b77-ec3f-11ea-9ba2-0242ac150002,app.changed.urls,1
+                jane@company.com,06164bd6-ec3f-11ea-9ba2-0242ac150002,2019-10-28T13:15:26Z,067589fd-ec3f-11ea-9ba2-0242ac150002,65.60.114.193,"{""id"": ""06768bbe-ec3f-11ea-9ba2-0242ac150002""}",067589b0-ec3f-11ea-9ba2-0242ac150002,app.changed.exclude_unknown_urls,1
+                john@company.com,378871f1-ec3e-11ea-b4d9-0242ac150002,2020-01-18T10:04:48Z,39018459-ec3e-11ea-b4d9-0242ac150002,92.128.231.122,"{""id"": ""06768bbe-ec3f-11ea-9ba2-0242ac150002""}",3901832e-ec3e-11ea-b4d9-0242ac150002,app.deleted,1
+                john@company.com,378871f1-ec3e-11ea-b4d9-0242ac150002,2019-12-15T04:31:24Z,3900b710-ec3e-11ea-b4d9-0242ac150002,15.23.2.241,"{""id"": ""0fa3fd75-b1b2-4897-8853-708211cebf0a""}",3900b5d3-ec3e-11ea-b4d9-0242ac150002,permission.user_group.changed.meta_site,1
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/EntryProperties"
+        400:
+          $ref: "#/components/responses/ListBadRequest"
+        401:
+          $ref: "#/components/responses/UnauthorizedError"
+        403:
+          $ref: "#/components/responses/AccessDeniedError"
+  /api/audit-log/v1/authors:
+    get:
+      summary: Authors list
+      description: Authors list of events
+      operationId: list_authors_v1
+      parameters:
+        - $ref: "#/components/parameters/EmailFilter"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+      responses:
+        200:
+          description: OK
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - meta
+                properties:
+                  meta:
+                    $ref: "#/components/schemas/Meta"
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - type
+                        - attributes
+                      properties:
+                        id:
+                          $ref: "#/components/schemas/Id"
+                        type:
+                          type: string
+                          enum:
+                            - ppms/user
+                        attributes:
+                          type: object
+                          required:
+                            - email
+                          properties:
+                            email:
+                              $ref: '#/components/schemas/Email'
+components:
+  parameters:
+    Limit:
+      name: limit
+      in: query
+      description: Limit for pagination
+      required: false
+      schema:
+        type: integer
+        default: 10
+        minimum: 0
+        maximum: 1000
+    Offset:
+      name: offset
+      in: query
+      description: Offset for pagination
+      required: false
+      schema:
+        type: integer
+        default: 0
+        minimum: 0
+    EmailFilter:
+      in: query
+      name: filter[email]
+      required: false
+      description: Email address search query
+      allowEmptyValue: true
+      schema:
+        type: string
+        example:
+          - piwik.pro
+    EntriesFilter:
+      in: query
+      name: filter
+      description: Filter items by provided criteria
+      style: deepObject
+      required: false
+      schema:
+        type: object
+        properties:
+          type:
+            description: Comma separated list of event types
+            example: app.added,app.edited
+            type: array
+            items:
+              $ref: "#/components/schemas/Type"
+          date_from:
+            description: Date from (ISO-8601 format)
+            example: 2020-01-01T00:00:00Z
+            type: string
+            format: "date-time"
+          date_to:
+            description: Date to (ISO-8601 format)
+            example: 2020-01-03T00:00:00Z
+            type: string
+            format: "date-time"
+          author_id:
+            description: Comma separated list of UUIDs of event authors
+            type: array
+            items:
+              $ref: "#/components/schemas/Id"
+          subject_id:
+            description: Comma separated list of UUIDs of event subjects (i.e. for `Meta site edited` it's the id of a meta site)
+            type: array
+            items:
+              $ref: "#/components/schemas/Id"
+          ip:
+            description: Comma serparated list of IPs
+            type: array
+            items:
+              $ref: "#/components/schemas/Ip"
+    Sort:
+      in: query
+      name: sort
+      description: Sort by field
+      schema:
+        type: string
+        default: -created_at
+        enum:
+          - type
+          - email
+          - created_at
+          - ip
+          - subject_id
+          - -type
+          - -email
+          - -created_at
+          - -ip
+          - -subject_id
+      required: false
+  schemas:
+    Id:
+      type: string
+      format: uuid
+      description: UUIDv4 identifier of an object
+      example: 6edb1e3c-4c43-4760-ab76-682ad83146be
+    EntryProperties:
+      type: object
+      required:
+        - created_at
+        - type
+        - payload
+        - author_id
+        - author_email
+        - subject_id
+        - ip
+        - version
+      properties:
+        created_at:
+          $ref: "#/components/schemas/CreatedAt"
+        type:
+          $ref: "#/components/schemas/Type"
+        payload:
+          $ref: "#/components/schemas/Payload"
+        author_id:
+          $ref: "#/components/schemas/Id"
+        author_email:
+          allOf:
+            - $ref: "#/components/schemas/Email"
+            - nullable: true
+        subject_id:
+          $ref: "#/components/schemas/Id"
+        ip:
+          allOf:
+            - $ref: "#/components/schemas/Ip"
+            - nullable: true
+        version:
+          $ref: "#/components/schemas/Version"
+    Entry:
+      type: object
+      required:
+        - id
+        - type
+        - attributes
+      properties:
+        id:
+          $ref: "#/components/schemas/Id"
+        type:
+          type: string
+          description: Resource type
+          enum:
+            - ppms/audit-log-entry
+        attributes:
+          $ref: "#/components/schemas/EntryProperties"
+    CreatedAt:
+      type: string
+      format: "date-time"
+      description: Timestamp of event occurrence (ISO-8601 format)
+      readOnly: true
+    Type:
+      type: string
+      description: Name of the event
+      example: app.added
+    Payload:
+      type: object
+      example:
+        id: 4faa8732-8877-40aa-b772-7b243bf60423
+        name: Important name
+    Ip:
+      description: Event author ip address (IPv4 or IPv6)
+      example: 193.17.41.169
+      type: string
+      oneOf:
+        - format: "IPv4"
+        - format: "IPv6"
+    Version:
+      description: Version of an event (e.g. version `1` of `app.added` could be not compatible with version `2`)
+      type: integer
+      minimum: 1
+    Email:
+      type: string
+      format: email
+      example: john@doe.com
+    QueryParamErrorObject:
+      allOf:
+        - $ref: "#/components/schemas/ErrorObject"
+        - properties:
+            errors:
+              type: array
+              items:
+                type: object
+                required:
+                  - status
+                  - code
+                  - title
+                properties:
+                  source:
+                    type: object
+                    properties:
+                      parameter:
+                        type: string
+                        description: string indicating which URI query parameter caused the error.
+                        example: filter[ip]
+    ErrorObject:
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            type: object
+            required:
+              - status
+              - code
+              - title
+            properties:
+              status:
+                type: string
+                description: the HTTP status code applicable to this problem, expressed as a string value
+                example: "400"
+              code:
+                type: string
+                description: an application-specific error code, expressed as a string value
+                example: invalid
+              detail:
+                type: string
+                description: a human-readable explanation specific to this occurrence of the problem. This field’s value can be localized
+                example: "'512.xxx.123' does not appear to be an IPv4 or IPv6 address"
+    Meta:
+      type: object
+      description: Response meta
+      required:
+        - total
+      properties:
+        total:
+          type: integer
+  responses:
+    ListBadRequest:
+      description: Bad Request
+      content:
+        "application/vnd.api+json":
+          schema:
+            $ref: "#/components/schemas/QueryParamErrorObject"
+    UnauthorizedError:
+      description: Unauthorized
+      content:
+        "application/json":
+          schema:
+            type: object
+            required:
+              - error
+            properties:
+              error:
+                type: string
+                example: authorization field missing
+    AccessDeniedError:
+      description: Forbidden
+      content:
+        "application/vnd.api+json":
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorObject"
+              - example:
+                  {
+                      "errors": [
+                          {
+                              "detail": "Authentication credentials were not provided.",
+                              "status": "403",
+                              "code": "not_authenticated"
+                          }
+                      ]
+                  }
+    NoJWTError:
+      description: Forbidden
+      content:
+        "application/vnd.api+json":
+          schema:
+            $ref: "#/components/schemas/ErrorObject"

--- a/platform/authorized_api/modules/public_v1.yaml
+++ b/platform/authorized_api/modules/public_v1.yaml
@@ -1,109 +1,467 @@
-swagger: '2.0'
-
+openapi: 3.0.0
 info:
   version: auto
   title: Modules API
-
 paths:
   /api/modules/v1:
     get:
       summary: Modules list
       description: List of licensed modules with access for a current user
       operationId: list_modules_v1
-      produces:
-        - application/vnd.api+json
       responses:
-        200:
+        "200":
           description: OK
-          schema:
-            type: object
-            required:
-              - data
-            properties:
-              data:
-                type: array
-                items:
-                  type: object
-                  required:
-                    - id
-                    - type
-                  properties:
-                    id:
-                      $ref: '#/definitions/ModuleId'
-                    type:
-                      type: string
-                      enum: [module]
-            example:
-              {
-                "data": [
-                {
-                  "id": "analytics",
-                  "type": "module"
-                },
-                {
-                  "id": "tag_manager",
-                  "type": "module"
-                }
-                ]
-              }
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - type
+                      properties:
+                        id:
+                          $ref: "#/components/schemas/ModuleId"
+                        type:
+                          type: string
+                          enum:
+                            - ppms/module
+                example:
+                  data:
+                    - id: analytics
+                      type: ppms/module
+                    - id: tag_manager
+                      type: ppms/module
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
   /api/modules/v1/by-users:
     post:
       summary: Modules list for given users
       description: List of modules with access for a list of users
       operationId: accessible_modules_for_users_batch
-      consumes:
-        - application/vnd.api+json
-      produces:
-        - application/vnd.api+json
-      parameters:
-        - name: payload
-          description: list of users
-          in: body
-          schema:
-            type: object
-            required:
-              - data
-            properties:
-              data:
-                type: array
-                maxItems: 100
-                items:
-                  $ref: '#/definitions/UserIdentifier'
-
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              required:
+                - data
+              properties:
+                data:
+                  type: array
+                  maxItems: 100
+                  items:
+                    $ref: "#/components/schemas/UserIdentifier"
+        description: list of users
       responses:
-        200:
+        "200":
           description: OK
-          schema:
-            type: object
-            required:
-              - data
-            properties:
-              data:
-                type: array
-                maxItems: 100
-                items:
-                  type: object
-                  required:
-                    - type
-                    - id
-                    - attributes
-                  properties:
-                    type:
-                      type: string
-                      enum: [ppms/user/modules]
-                    id:
-                      $ref: '#/definitions/Id'
-                    attributes:
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    maxItems: 100
+                    items:
                       type: object
                       required:
-                        - modules
+                        - type
+                        - id
+                        - attributes
                       properties:
-                        modules:
-                          type: array
-                          items:
-                            $ref: '#/definitions/ModuleId'
-        400:
+                        type:
+                          type: string
+                          enum:
+                            - ppms/user/modules
+                        id:
+                          $ref: "#/components/schemas/Id"
+                        attributes:
+                          type: object
+                          required:
+                            - modules
+                          properties:
+                            modules:
+                              type: array
+                              items:
+                                $ref: "#/components/schemas/ModuleId"
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "409":
+          $ref: '#/components/responses/ConflictUserError'
+        "415":
+          $ref: '#/components/responses/UnsupportedMediaTypeError'
+  /api/modules/v1/by-user-groups:
+    post:
+      summary: Modules list for given user groups
+      description: List of modules with access for a list of user groups
+      operationId: accessible_modules_for_user_groups_batch
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              required:
+                - data
+              properties:
+                data:
+                  type: array
+                  maxItems: 100
+                  items:
+                    $ref: "#/components/schemas/UserGroupIdentifier"
+        description: list of user groups
+      responses:
+        "200":
+          description: OK
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    maxItems: 100
+                    items:
+                      type: object
+                      required:
+                        - type
+                        - id
+                        - attributes
+                      properties:
+                        type:
+                          type: string
+                          enum:
+                            - ppms/user-group/modules
+                        id:
+                          $ref: "#/components/schemas/Id"
+                        attributes:
+                          type: object
+                          required:
+                            - modules
+                          properties:
+                            modules:
+                              type: array
+                              items:
+                                $ref: "#/components/schemas/ModuleId"
+        "400":
           description: Bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                required:
+                  - errors
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ErrorObject"
+                example:
+                  errors:
+                    - status: "400"
+                      code: modules.error.too-many-user-groups
+                      detail: This collection contains 101 elements. It should have
+                        100 elements or less.
+                      source:
+                        pointer: /data
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "409":
+          $ref: "#/components/responses/ConflictUserGroupError"
+        "415":
+          $ref: '#/components/responses/UnsupportedMediaTypeError'
+  "/api/modules/v1/{module}":
+    get:
+      summary: Module
+      description: Returns module if it is licensed and user has access to it
+      operationId: get_module_v1
+      parameters:
+        - $ref: "#/components/parameters/Module"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: object
+                    required:
+                      - id
+                      - type
+                    properties:
+                      id:
+                        $ref: "#/components/schemas/ModuleId"
+                      type:
+                        type: string
+                        enum:
+                          - module
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/AccessToModuleDeniedError"
+        "404":
+          $ref: "#/components/responses/NotFoundModule"
+  "/api/modules/v1/access/user/{user_id}":
+    get:
+      summary: Modules access list for a given user
+      description: >
+        Lists all modules to which a given user has access to.
+
+        List contains both explicit access for a user and implicit access inherited from user groups which user belongs to.
+      operationId: get_user_modules_access_v1
+      parameters:
+        - $ref: "#/components/parameters/UserId"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ModulesAccessForUser"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/NoJWTError"
+        "404":
+          $ref: "#/components/responses/NotFoundUser"
+    put:
+      summary: Set modules access for a given user
+      description: Sets modules access for a given user
+      operationId: set_modules_access_v1
+      parameters:
+        - $ref: "#/components/parameters/UserId"
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              required:
+                - data
+              properties:
+                data:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - id
+                      - attributes
+                    properties:
+                      type:
+                        type: string
+                        description: Resource type
+                        enum:
+                          - module/access
+                      id:
+                        $ref: "#/components/schemas/ModuleId"
+                      attributes:
+                        type: object
+                        required:
+                          - access
+                        properties:
+                          access:
+                            type: boolean
+      responses:
+        "204":
+          description: No Content
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/SetAccessForUnlicensedModuleError"
+        "404":
+          $ref: "#/components/responses/NotFoundUser"
+        "409":
+          $ref: "#/components/responses/ConflictModulesAccessError"
+        "415":
+          $ref: '#/components/responses/UnsupportedMediaTypeError'
+  "/api/modules/v1/access/user-group/{user_group_id}":
+    get:
+      summary: Modules access list for a given user group
+      description: >
+        Lists all modules to which a given user group has access to.
+      operationId: get_user_group_modules_access_v1
+      parameters:
+        - $ref: "#/components/parameters/UserGroupId"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ModulesAccessForUserGroup"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/NoJWTError"
+        "404":
+          $ref: "#/components/responses/NotFoundUserGroup"
+    put:
+      summary: Set modules access for a given user group
+      description: Sets modules access for a given user group
+      operationId: set_modules_access_v1
+      parameters:
+        - $ref: "#/components/parameters/UserGroupId"
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              required:
+                - data
+              properties:
+                data:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - id
+                      - attributes
+                    properties:
+                      type:
+                        type: string
+                        description: Resource type
+                        enum:
+                          - module/access
+                      id:
+                        $ref: "#/components/schemas/ModuleId"
+                      attributes:
+                        type: object
+                        required:
+                          - access
+                        properties:
+                          access:
+                            type: boolean
+      responses:
+        "204":
+          description: No Content
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/SetAccessForUnlicensedModuleError"
+        "404":
+          $ref: "#/components/responses/NotFoundUserGroup"
+        "409":
+          $ref: "#/components/responses/ConflictModulesAccessError"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaTypeError"
+components:
+  parameters:
+    Module:
+      in: path
+      name: module
+      required: true
+      schema:
+        type: string
+        enum:
+          - analytics
+          - piwik
+          - consent_manager
+          - tag_manager
+          - administration
+          - audience_manager
+    UserId:
+      in: path
+      name: user_id
+      required: true
+      description: UUIDv4 identifier of an object
+      schema:
+        type: string
+        format: uuid
+    UserGroupId:
+      in: path
+      name: user_group_id
+      required: true
+      description: UUIDv4 identifier of an object
+      schema:
+        type: string
+        format: uuid
+  responses:
+    NotFoundModule:
+      description: Not Found
+      content:
+        "application/vnd.api+json":
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorObject"
+              - example:
+                  errors:
+                    - status: "404"
+                      code: module.not-exists
+                      title: Module 'personalization' does not exist. Available
+                        modules are [analytics, piwik, consent_manager,
+                        tag_manager, administration, audience_manager]
+    NotFoundUser:
+      description: Not Found
+      content:
+        "application/vnd.api+json":
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorObject"
+              - example:
+                  errors:
+                    - status: "404"
+                      code: modules.error.user-not-exists
+                      detail: User 704a6202-d899-4968-aba3-71758457bec1 does not exist
+    NotFoundUserGroup:
+      description: Not Found
+      content:
+        "application/vnd.api+json":
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorObject"
+              - example:
+                  errors:
+                    - status: "404"
+                      code: modules.error.user-group-not-exists
+                      detail: User group 704a6202-d899-4968-aba3-71758457bec1 does not exist
+    UnauthorizedError:
+      description: Unauthorized
+      content:
+        "application/json":
+          schema:
+            type: object
+            required:
+              - error
+            properties:
+              error:
+                type: string
+                example: access token not authorized
+    BadRequest:
+      description: Bad request
+      content:
+        application/vnd.api+json:
           schema:
             type: object
             required:
@@ -112,308 +470,236 @@ paths:
               errors:
                 type: array
                 items:
-                  $ref: '#/definitions/ErrorObject'
+                  $ref: "#/components/schemas/ErrorObject"
             example:
-              {
-                "errors": [
-                {
-                  "status": "400",
-                  "code": "error.default",
-                  "title": "Invalid form",
-                  "detail": "This collection should contain 100 elements or less.",
-                  "source": {
-                    "pointer": "/data"
-                  }
-                }
-                ]
-              }
-  /api/modules/v1/{module}:
-    get:
-      summary: Module
-      description: Returns module if it is licensed and user has access to it
-      operationId: get_module_v1
-      produces:
-        - application/vnd.api+json
-      parameters:
-        - $ref: '#/parameters/Module'
-      responses:
-        200:
-          description: OK
+              errors:
+                - status: "400"
+                  code: modules.error.too-many-users
+                  detail: This collection contains 101 elements. It should have
+                    100 elements or less.
+                  source:
+                    pointer: /data
+    ConflictUserError:
+      description: Conflict
+      content:
+        "application/vnd.api.json":
           schema:
-            type: object
-            required:
-              - data
-            properties:
-              data:
-                type: object
-                required:
-                  - id
-                  - type
-                properties:
-                  id:
-                    $ref: '#/definitions/ModuleId'
-                  type:
-                    type: string
-                    enum: [module]
-        401:
-          $ref: '#/responses/UnauthorizedError'
-        403:
-          $ref: '#/responses/ForbiddenError'
-        404:
-          $ref: '#/responses/NotFoundModule'
-  /api/modules/v1/access/user/{user_id}:
-    get:
-      summary: Modules access list for a given user
-      description: |
-        Lists all modules to which a given user has access to.
-        List contains both explicit access for a user and implicit access inherited from user groups which user belongs to.
-      operationId: get_user_modules_access_v1
-      produces:
-        - application/vnd.api+json
-      parameters:
-        - $ref: '#/parameters/UserId'
-      responses:
-        200:
-          description: OK
+            allOf:
+              - $ref: "#/components/schemas/ErrorObject"
+              - example:
+                  errors:
+                    - status: "409"
+                      code: error
+                      source:
+                        pointer: "/data"
+                      detail: The resource object's type (INVALID) is not the type that constitute the collection represented by the endpoint (ppms/user).
+    ConflictUserGroupError:
+      description: Conflict
+      content:
+        "application/vnd.api.json":
           schema:
-            type: object
-            required:
-              - data
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/ModulesAccessForUser'
-        401:
-          $ref: '#/responses/UnauthorizedError'
-        403:
-          $ref: '#/responses/ForbiddenError'
-        404:
-          $ref: '#/responses/NotFoundUser'
-    put:
-      summary: Set modules access for a given user
-      description: Sets modules access for a given user
-      operationId: set_modules_access_v1
-      consumes:
-        - application/vnd.api+json
-      parameters:
-        - $ref: '#/parameters/UserId'
-        - name: payload
-          in: body
+            allOf:
+              - $ref: "#/components/schemas/ErrorObject"
+              - example:
+                  errors:
+                    - status: "409"
+                      code: error
+                      source:
+                        pointer: "/data"
+                      detail: The resource object's type (INVALID) is not the type that constitute the collection represented by the endpoint (ppms/user-group).
+    ConflictModulesAccessError:
+      description: Conflict
+      content:
+        "application/vnd.api.json":
           schema:
-            type: object
-            required:
-              - data
-            properties:
-              data:
-                type: array
-                items:
-                  type: object
-                  required:
-                    - type
-                    - id
-                    - attributes
-                  properties:
-                    type:
-                      type: string
-                      description: Resource type
-                      enum: [module/access]
-                    id:
-                      $ref: '#/definitions/ModuleId'
-                    attributes:
-                      type: object
-                      required:
-                        - access
-                      properties:
-                        access:
-                          type: boolean
-      responses:
-        204:
-          description: No Content
-        401:
-          $ref: '#/responses/UnauthorizedError'
-        403:
-          $ref: '#/responses/ForbiddenError'
-        404:
-          $ref: '#/responses/NotFoundUser'
-
-
-parameters:
-  Module:
-    in: path
-    name: module
-    type: string
-    enum:
-      - analytics
-      - piwik
-      - consent_manager
-      - tag_manager
-      - administration
-      - audience_manager
-    required: true
-  UserId:
-    in: path
-    name: user_id
-    type: string
-    format: uuid
-    required: true
-    description: UUIDv4 identifier of an object
-
-definitions:
-  Id:
-    type: string
-    format: uuid
-    description: UUIDv4 identifier of an object
-    example: 6edb1e3c-4c43-4760-ab76-682ad83146be
-  ModuleId:
-    type: string
-    enum:
-      - analytics
-      - piwik
-      - consent_manager
-      - tag_manager
-      - administration
-      - audience_manager
-    description: ID of a module
-  UserIdentifier:
-    type: object
-    properties:
-      type:
-        description: Resource type
-        type: string
-        enum: [ppms/user]
-      id:
-        $ref: '#/definitions/Id'
-  ModulesAccessForUser:
-    type: object
-    required:
-      - id
-      - type
-      - attributes
-    properties:
-      id:
-        $ref: '#/definitions/ModuleId'
-      type:
-        type: string
-        description: Resource type
-        enum: [module/access/user]
-      attributes:
-        type: object
-        required:
-          - group_access
-          - access
-        properties:
-          group_access:
-            type: object
-            required:
-              - group_names
-              - access
-            properties:
-              group_names:
-                type: array
-                items:
-                  type: string
-                  example: Managers
-              access:
-                type: boolean
-          access:
-            type: boolean
-  ErrorObject:
-    type: object
-    required:
-      - status
-      - title
-    properties:
-      status:
-        type: string
-        description: the HTTP status code applicable to this problem, expressed as a string value
-        example: "400"
-      code:
-        type: string
-        description: an application-specific error code, expressed as a string value
-        example: error.default
-      title:
-        type: string
-        description: >
-          a short, human-readable summary of the problem that SHOULD NOT change from occurrence
-          to occurrence of the problem, except for purposes of localization
-        example: Invalid form
-      detail:
-        type: string
-        description: >
-          a human-readable explanation specific to this occurrence of the problem.
-          Like `title`, this field’s value can be localized
-        example: This field is invalid
-      source:
-        type: object
-        description: >
-          an object containing references to the source of the error, optionally including any of the
-          following members: [pointer, parameter]
-        properties:
-          pointer:
-            type: string
-            example: /data/attributes/name
-            description: >
-              a JSON Pointer [RFC6901] to the associated entity in the request document
-              [e.g. "/data" for a primary data object, or "/data/attributes/name" for a specific attribute]
-          parameter:
-            type: string
-            example: offset
-            description: a string indicating which URI query parameter caused the error
-responses:
-  NotFoundModule:
-    description: 'Not Found'
-    schema:
-      allOf:
-        - $ref: '#/definitions/ErrorObject'
-        - example:
-            {
-              "errors": [
-              {
-                "status": "404",
-                "code": "module.not-exists",
-                "title": "Module \"personalization\" does not exist"
-              }
-              ]
-            }
-  NotFoundUser:
-    description: 'Not Found'
-    schema:
-      allOf:
-        - $ref: '#/definitions/ErrorObject'
-        - example:
-            {
-              "errors": [
-              {
-                "status": "404",
-                "code": "users.error.user-does-not-exist",
-                "title": "User \"704a6202-d899-4968-aba3-71758457bec1\" does not exist"
-              }
-              ]
-            }
-  UnauthorizedError:
-    description: 'Unauthorized'
-    schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorObject"
+              - example:
+                  errors:
+                    - status: "409"
+                      code: error
+                      source:
+                        pointer: "/data"
+                      detail: The resource object's type (INVALID) is not the type that constitute the collection represented by the endpoint (module/access).
+    AccessToModuleDeniedError:
+      description: Forbidden
+      content:
+        "application/vnd.api+json":
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorObject"
+              - example:
+                  errors:
+                    - status: "403"
+                      code: modules.error.access-denied
+                      detail: Access to module 'analytics' is revoked
+    SetAccessForUnlicensedModuleError:
+      description: Forbidden
+      content:
+        "application/vnd.api+json":
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorObject"
+              - example:
+                  errors:
+                    - status: "403"
+                      code: modules.error.unlicensed-module
+                      detail: "Missing license for: analytics"
+    NoJWTError:
+      description: Forbidden
+      content:
+        "application/vnd.api+json":
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorObject"
+              - example:
+                  errors:
+                    - status: "403"
+                      code: authentication_failed
+                      detail: Missing or invalid Authorization header
+    UnsupportedMediaTypeError:
+      description: Unsupported Media Type
+      content:
+        "application/vnd.api+json":
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorObject"
+              - example:
+                  errors:
+                    - status: "415"
+                      code: unsupported_media_type
+                      source:
+                        pointer: "/data"
+                      detail: Unsupported media type "UNSUPPORTED" in request.
+  schemas:
+    Id:
+      type: string
+      format: uuid
+      description: UUIDv4 identifier of an object
+      example: 6edb1e3c-4c43-4760-ab76-682ad83146be
+    ModuleId:
+      type: string
+      enum:
+        - analytics
+        - piwik
+        - consent_manager
+        - tag_manager
+        - administration
+        - audience_manager
+      description: ID of a module
+    UserIdentifier:
+      type: object
+      properties:
+        type:
+          description: Resource type
+          type: string
+          enum:
+            - ppms/user
+        id:
+          $ref: "#/components/schemas/Id"
+    UserGroupIdentifier:
+      type: object
+      properties:
+        type:
+          description: Resource type
+          type: string
+          enum:
+            - ppms/user-group
+        id:
+          $ref: "#/components/schemas/Id"
+    ModulesAccessForUser:
       type: object
       required:
-        - error
+        - id
+        - type
+        - attributes
       properties:
-        error:
+        id:
+          $ref: "#/components/schemas/ModuleId"
+        type:
           type: string
-          example: access token not authorized
-
-  ForbiddenError:
-    description: 'Forbidden'
-    schema:
-      allOf:
-        - $ref: '#/definitions/ErrorObject'
-        - example:
-            {
-              "errors": [
-              {
-                "status": "403",
-                "code": "error.forbidden",
-                "title": "Access denied."
-              }
-              ]
-            }
+          description: Resource type
+          enum:
+            - module/access/user
+        attributes:
+          type: object
+          required:
+            - group_access
+            - access
+          properties:
+            group_access:
+              type: object
+              required:
+                - group_names
+                - access
+              properties:
+                group_names:
+                  type: array
+                  items:
+                    type: string
+                    example: Managers
+                access:
+                  type: boolean
+            access:
+              type: boolean
+    ModulesAccessForUserGroup:
+      type: object
+      required:
+        - id
+        - type
+        - attributes
+      properties:
+        id:
+          $ref: "#/components/schemas/ModuleId"
+        type:
+          type: string
+          description: Resource type
+          enum:
+            - module/access/user-group
+        attributes:
+          type: object
+          required:
+            - access
+          properties:
+            access:
+              type: boolean
+    ErrorObject:
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            type: object
+            required:
+              - status
+              - code
+              - detail
+              - source
+            properties:
+              status:
+                type: string
+                description: the HTTP status code applicable to this problem, expressed as a
+                  string value
+                example: "400"
+              code:
+                type: string
+                description: an application-specific error code, expressed as a string value
+                example: error.default
+              detail:
+                type: string
+                description: >
+                  a human-readable explanation specific to this occurrence of the
+                  problem. Like `title`, this field’s value can be localized
+                example: This field is invalid
+              source:
+                type: object
+                description: >
+                  an object containing references to the source of the error, optionally including any of the
+                  following members: [pointer, parameter]
+                properties:
+                  pointer:
+                    type: string
+                    example: /data
+                    description: >
+                      a JSON Pointer [RFC6901] to the associated entity in the request document
+                      [e.g. "/data" for a primary data object, or "/data/attributes/name" for a specific attribute]

--- a/platform/index.rst
+++ b/platform/index.rst
@@ -7,6 +7,7 @@ Platform
   authorized_api_guide
   authorized_api/access_control/access_control_api
   authorized_api/apps/apps_api
+  authorized_api/audit_log/audit_log_api
   authorized_api/meta_sites/meta_sites_api
   authorized_api/modules/modules_api
   authorized_api/tracker_settings/tracker_settings_api


### PR DESCRIPTION
there was a problem with dumping json from yaml containing iso date:
```python
import yaml, json
... 
... jaml = yaml.safe_load("date: 2020-01-01T00:00:00Z")
jaml
{'date': datetime.datetime(2020, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)}
json.dumps(jaml)
Traceback (most recent call last):
  File "/usr/lib/python3.8/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<input>", line 1, in <module>
  File "/usr/lib/python3.8/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type datetime is not JSON serializable
```