### PR TITLE
PPTT-1496 Added JS tracker reserved names

### DIFF
--- a/tracker/index.rst
+++ b/tracker/index.rst
@@ -4,6 +4,7 @@ Tracker
 .. toctree::
     :maxdepth: 2
 
+    reserved_names
     js_tracking_api
     tracker_object
     http_api

--- a/tracker/reserved_names.rst
+++ b/tracker/reserved_names.rst
@@ -1,0 +1,21 @@
+.. highlight:: js
+.. default-domain:: js
+
+Global reserved names used by JavaScript tracker API
+====================================================
+The following global names are used by PPAS JavaScript tracker. Websites that will use this tracker should avoid using variables with identical names.
+
+* ``Piwik``
+* ``_paq``
+* ``JSON_PIWIK``
+* ``piwikPluginAsyncInit``
+* ``piwikAsyncInit``
+* ``AnalyticsTracker``
+* ``piwik_install_tracker``
+* ``piwik_tracker_pause``
+* ``piwik_download_extensions``
+* ``piwik_hosts_alias``
+* ``piwik_ignore_classes``
+* ``piwik_log``
+* ``piwik_track``
+* ``sevenTag``


### PR DESCRIPTION
This info is valid also for older versions, but we moved catalog structure in this version so it'll be harder to merge changes from previous versions. Let me know if you want to update all docs starting from 6.0.

Preview:
https://developers.piwik.pro/en/feature-pptt-1496-added-tracker-js-reserved-names/tracker/reserved_names.html