### PR TITLE
TM-7640: Mark referral_cookie_timeout as deprecated in TM API documentation

### DIFF
--- a/tag_manager/authorized_api/src/tags/schema/tag_templates/piwik_attributes.json
+++ b/tag_manager/authorized_api/src/tags/schema/tag_templates/piwik_attributes.json
@@ -152,8 +152,9 @@
             "type": "integer"
         },
         "template_options_referral_cookie_timeout": {
-            "description": "Referral cookie timeout in seconds",
-            "type": "integer"
+            "description": "Referral cookie timeout in seconds (is ignored and will be removed in next version)",
+            "type": "integer",
+            "deprecated": true
         },
         "template_options_session_cookie_timeout": {
             "description": "Session cookie timeout in seconds",


### PR DESCRIPTION
Marks referral_cookie_timeout option for Piwik PRO Analytics tag as deprecated