### PR TITLE
TM-7968: Make it clear where to find CM JS API usage examples

### DIFF
--- a/consent_manager/custom_consent_form/example.rst
+++ b/consent_manager/custom_consent_form/example.rst
@@ -1,6 +1,8 @@
 .. _`Piwik PRO - Custom consent form example`: https://piwikpro.github.io/ConsentManager-CustomConsentFormExample/
+.. _JavaScript API: ../js_api/
 
 Example implementation
 ----------------------
 
-Visit `Piwik PRO - Custom consent form example`_ page to discover a live demo of Custom consent form implementation.
+Visit `Piwik PRO - Custom consent form example`_ page to discover a live demo of Custom consent form implementation
+(including examples of how to track consent stats using `JavaScript API`_).

--- a/consent_manager/js_api/commands.rst
+++ b/consent_manager/js_api/commands.rst
@@ -1,6 +1,14 @@
+.. _`Piwik PRO - Custom consent form example`: https://piwikpro.github.io/ConsentManager-CustomConsentFormExample/
+
 Commands
 --------
 All commands work in the context of the current visitor and website. Additionally, they sometimes require communication with a PPAS server and are asynchronous. Callback functions are used to provide response value or information about errors. ``onSuccess(...args)`` callback is required, with the exception of ``openConsentForm`` command where it is optional. ``onFailure(exception)`` callback is optional and if is specified, any error object occurred will be passed as an argument. If not specified, an error is reported directly on the console output.
+
+.. note::
+    For examples of how to use a specific command in your custom consent form
+    implementation (including how to track consent stats), reffer to the
+    `Piwik PRO - Custom consent form example`_
+
 
 Get compliance types
 ````````````````````


### PR DESCRIPTION
- add information that consent stats tracking is included in the example implementation
- provide additional links to the custom consent form implementation in Commands section