### PR TITLE
PPTT-2923 Hidden log import for early versions of new tracker

### DIFF
--- a/tracker/index.rst
+++ b/tracker/index.rst
@@ -8,5 +8,4 @@ Tracker
     js_tracking_api
     tracker_object
     http_api
-    web_log_analytics
     tracker_debugger_api

--- a/tracker/web_log_analytics.rst
+++ b/tracker/web_log_analytics.rst
@@ -112,7 +112,7 @@ Technical requirements
 Technical requirements for running Web Log Analytics:
 
 - Access to the server or server logs – for example via SSH
-- Python 2.6 or 2.7 – versions 3.x are not supported. Most often you’ll want to import your data straight from the server where it is created. To do this, you’ll need to be able to run a Python script on the machine that will send the logs to Piwik PRO.
+ - Python 3.5+ – older versions (e.g. 2.6 or 2.7) are not supported. Most often you’ll want to import your data straight from the server where it is created. To do this, you’ll need to be able to run a Python script on the machine that will send the logs to Piwik PRO
 - Log Importer tool – this is a script written in Python ensuring that logs are sent to your Piwik instance.
 
 Supported log formats:


### PR DESCRIPTION
I'm hiding link to log importer as discussed, but I'm starting to wonder if this is correct solution since log importer works for this versions with `--replay-traffic`.