### PR TITLE
Correct placements of example values

### DIFF
--- a/data_collection/mobile/Piwik_PRO_SDK_for_Flutter.md
+++ b/data_collection/mobile/Piwik_PRO_SDK_for_Flutter.md
@@ -38,7 +38,7 @@ import 'package:flutter_piwikpro/flutter_piwikpro.dart';
 You'll need to configure the tracker before using any other methods - for that you will need the base URL address of your tracking server and website ID (you can find it in Administration > Websites & apps > Installation on the web interface).
 
 ```dart
-await FlutterPiwikPro.sharedInstance.configureTracker(baseURL: '01234567-89ab-cdef-0123-456789abcdef', siteId: 'https://your.piwik.pro.server.com');
+await FlutterPiwikPro.sharedInstance.configureTracker(baseURL: 'https://your.piwik.pro.server.com', siteId: '01234567-89ab-cdef-0123-456789abcdef');
 ```
 
 ##### iOS and Android parameters:


### PR DESCRIPTION
Looks like values for baseURL and siteId were mixed up between each other, I just replaced them so they match.