### PR TITLE
TM-10546 Rebrand tags to Meta Pixel, Floodlight Sales and Floodlight Counter. Add deprecations.

### DIFF
--- a/tag_manager/authorized_api/src/changelog.yaml
+++ b/tag_manager/authorized_api/src/changelog.yaml
@@ -1,8 +1,10 @@
 openapi: '3.0.0'
 info:
     title: Tag Manager API
-    description: In order to access those endpoints, you need to **authenticate**. <a href="../../platform/getting_started.html">Here is a guide on how to do it.</a>
     version: '1.0'
+
+security:
+    - BearerAuth: []
 
 servers:
     - url: https://example.piwik.pro
@@ -39,3 +41,6 @@ paths:
                 '500':
                     $ref: 'common/api/common_error_responses.json#/components/responses/internal_server_error'
 
+components:
+    securitySchemes:
+        $ref: 'common/api/common_security_schemes.json#/components/securitySchemes'

--- a/tag_manager/authorized_api/src/changelog/schema/changelog_content_attributes.json
+++ b/tag_manager/authorized_api/src/changelog/schema/changelog_content_attributes.json
@@ -115,23 +115,23 @@
                             "$ref": "../../tags/schema/tag_templates/crazy_egg_attributes.json#/definitions/template_options"
                         },
                         {
-                            "title": "DoubleClick Floodlight Sales (item sold)",
+                            "title": "Floodlight Sales (item sold)",
                             "$ref": "../../tags/schema/tag_templates/doubleclick_floodlight/doubleclick_floodlight_sales_item_sold_attributes.json#/definitions/template_options"
                         },
                         {
-                            "title": "DoubleClick Floodlight Sales (transactions)",
+                            "title": "Floodlight Sales (transactions)",
                             "$ref": "../../tags/schema/tag_templates/doubleclick_floodlight/doubleclick_floodlight_sales_transactions_attributes.json#/definitions/template_options"
                         },
                         {
-                            "title": "DoubleClick Floodlight Counter (session)",
+                            "title": "Floodlight Counter (session)",
                             "$ref": "../../tags/schema/tag_templates/doubleclick_floodlight/doubleclick_floodlight_counter_session_attributes.json#/definitions/template_options"
                         },
                         {
-                            "title": "DoubleClick Floodlight Counter (standard_method)",
+                            "title": "Floodlight Counter (standard_method)",
                             "$ref": "../../tags/schema/tag_templates/doubleclick_floodlight/doubleclick_floodlight_counter_standard_method_attributes.json#/definitions/template_options"
                         },
                         {
-                            "title": "DoubleClick Floodlight Counter (unique_method)",
+                            "title": "Floodlight Counter (unique_method)",
                             "$ref": "../../tags/schema/tag_templates/doubleclick_floodlight/doubleclick_floodlight_counter_unique_method_attributes.json#/definitions/template_options"
                         },
                         {
@@ -139,7 +139,7 @@
                             "$ref": "../../tags/schema/tag_templates/google_adwords/google_adwords_doubleclick_attributes.json#/definitions/template_options"
                         },
                         {
-                            "title": "Facebook Retargeting Pixel",
+                            "title": "Meta Pixel",
                             "$ref": "../../tags/schema/tag_templates/facebook_retargeting_pixel_attributes.json#/definitions/template_options"
                         },
                         {

--- a/tag_manager/authorized_api/src/operations.yaml
+++ b/tag_manager/authorized_api/src/operations.yaml
@@ -1,8 +1,10 @@
 openapi: '3.0.0'
 info:
     title: Tag Manager API
-    description: In order to access those endpoints, you need to **authenticate**. <a href="../../platform/getting_started.html">Here is a guide on how to do it.</a>
     version: '1.0'
+
+security:
+    - BearerAuth: []
 
 servers:
     - url: https://example.piwik.pro
@@ -31,3 +33,6 @@ paths:
                 '500':
                     $ref: 'common/api/common_error_responses.json#/components/responses/internal_server_error'
 
+components:
+    securitySchemes:
+        $ref: 'common/api/common_security_schemes.json#/components/securitySchemes'

--- a/tag_manager/authorized_api/src/tags.yaml
+++ b/tag_manager/authorized_api/src/tags.yaml
@@ -1,10 +1,38 @@
 openapi: '3.0.0'
 info:
     title: Tag Manager API
-    description: |
-        - In order to access those endpoints, you need to **authenticate**. <a href="../../platform/getting_started.html">Here is a guide on how to do it.</a>
-        - <span id="tag-template-options">Tag template options</span> - one should send all attributes he wants to be set when using PATCH request
     version: '1.0'
+    description: |
+        # Tag template options
+        One should send all attributes he wants to be set when using PATCH request.
+        
+        # Deprecations and changes
+        
+        <details>
+        <summary>Deprecated tags</summary>
+        The tags listed below are marked as deprecated and will not be supported soon. 
+        We strongly discourage using them.
+            
+        | Deprecated tags               |      
+        |---                            |
+        | Clicktale Tracking Code tag   |
+        | DoubleClick Conversion tag    |
+        
+        </details>
+        
+        <details>
+        <summary>Renamed tags</summary>
+        The following tags have been rebranded. However, their template attribute value remained the same due to maintaining backward compatibility.
+        
+        | Old tag name                      | New tag name          |
+        |---                                |---                    |
+        | Facebook Retargeting Pixel tag    | Meta Pixel tag        |
+        | DoubleClick Floodlight Sales tag  | Floodlight Sales tag  |
+        | DoubleClick Floodlight Counter tag| Floodlight Counter tag|
+        
+        </details>
+security:
+    - BearerAuth: []
 
 servers:
     - url: https://example.piwik.pro
@@ -80,6 +108,8 @@ paths:
 
         post:
             summary: Create tag
+            description: |
+                See more details about API changes: <a href="#section/Deprecations-and-changes">Deprecations and changes</a>
             requestBody:
                 required: true
                 content:
@@ -142,6 +172,8 @@ paths:
 
         patch:
             summary: Edit tag
+            description: |
+                See more details about API changes: <a href="#section/Deprecations-and-changes">Deprecations and changes</a>
             requestBody:
                 required: true
                 content:
@@ -215,3 +247,6 @@ paths:
                         example:
                             $ref: 'tags/example/copy/tags_copy_request_example.json'
 
+components:
+    securitySchemes:
+        $ref: 'common/api/common_security_schemes.json#/components/securitySchemes'

--- a/tag_manager/authorized_api/src/tags/schema/create/request/click_tale_create.json
+++ b/tag_manager/authorized_api/src/tags/schema/create/request/click_tale_create.json
@@ -1,10 +1,12 @@
 {
-    "title": "Clicktale tag",
+    "title": "Clicktale tag [DEPRECATED]",
     "description": "Clicktale tag create request",
+    "deprecated": true,
     "type": "object",
     "properties": {
         "data": {
             "title": "JSON:API 1.0 request data",
+            "deprecated": true,
             "type": "object",
             "properties": {
                 "id": {

--- a/tag_manager/authorized_api/src/tags/schema/create/request/doubleclick_floodlight_counter_session_create.json
+++ b/tag_manager/authorized_api/src/tags/schema/create/request/doubleclick_floodlight_counter_session_create.json
@@ -1,6 +1,6 @@
 {
-    "title": "DoubleClick Floodlight Counter (session) tag",
-    "description": "DoubleClick Floodlight Counter (session) tag create request",
+    "title": "Floodlight Counter (session) tag",
+    "description": "Floodlight Counter (session) tag create request. (Rebranded from DoubleClick Floodlight Counter)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "DoubleClick Floodlight Counter (session) tag attributes",
+                    "description": "Floodlight Counter (session) tag attributes",
                     "type": "object",
                     "properties": {
                         "disable_in_debug_mode": {

--- a/tag_manager/authorized_api/src/tags/schema/create/request/doubleclick_floodlight_counter_standard_method_create.json
+++ b/tag_manager/authorized_api/src/tags/schema/create/request/doubleclick_floodlight_counter_standard_method_create.json
@@ -1,6 +1,6 @@
 {
-    "title": "DoubleClick Floodlight Counter (standard_method) tag",
-    "description": "DoubleClick Floodlight Counter (standard_method) tag create request",
+    "title": "Floodlight Counter (standard_method) tag",
+    "description": "Floodlight Counter (standard_method) tag create request. (Rebranded from DoubleClick Floodlight Counter)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "DoubleClick Floodlight Counter (standard_method) tag attributes",
+                    "description": "Floodlight Counter (standard_method) tag attributes",
                     "type": "object",
                     "properties": {
                         "disable_in_debug_mode": {

--- a/tag_manager/authorized_api/src/tags/schema/create/request/doubleclick_floodlight_counter_unique_method_create.json
+++ b/tag_manager/authorized_api/src/tags/schema/create/request/doubleclick_floodlight_counter_unique_method_create.json
@@ -1,6 +1,6 @@
 {
-    "title": "DoubleClick Floodlight Counter (unique_method) tag",
-    "description": "DoubleClick Floodlight Counter (unique_method) tag create request",
+    "title": "Floodlight Counter (unique_method) tag",
+    "description": "Floodlight Counter (unique_method) tag create request. (Rebranded from DoubleClick Floodlight Counter)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "DoubleClick Floodlight Counter (unique_method) tag attributes",
+                    "description": "Floodlight Counter (unique_method) tag attributes",
                     "type": "object",
                     "properties": {
                         "disable_in_debug_mode": {

--- a/tag_manager/authorized_api/src/tags/schema/create/request/doubleclick_floodlight_sales_item_sold_create.json
+++ b/tag_manager/authorized_api/src/tags/schema/create/request/doubleclick_floodlight_sales_item_sold_create.json
@@ -1,6 +1,6 @@
 {
-    "title": "DoubleClick Floodlight Sales (item_sold) tag",
-    "description": "DoubleClick Floodlight Sales (item_sold) tag create request",
+    "title": "Floodlight Sales (item_sold) tag",
+    "description": "Floodlight Sales (item_sold) tag create request. (Rebranded from DoubleClick Floodlight Sales)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "DoubleClick Floodlight Sales (item_sold) tag attributes",
+                    "description": "Floodlight Sales (item_sold) tag attributes",
                     "type": "object",
                     "properties": {
                         "disable_in_debug_mode": {

--- a/tag_manager/authorized_api/src/tags/schema/create/request/doubleclick_floodlight_sales_transactions_create.json
+++ b/tag_manager/authorized_api/src/tags/schema/create/request/doubleclick_floodlight_sales_transactions_create.json
@@ -1,6 +1,6 @@
 {
-    "title": "DoubleClick Floodlight Sales (transactions) tag",
-    "description": "DoubleClick Floodlight Sales (transactions) tag create request",
+    "title": "Floodlight Sales (transactions) tag",
+    "description": "Floodlight Sales (transactions) tag create request. (Rebranded from DoubleClick Floodlight Sales)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "DoubleClick Floodlight Sales (transactions) tag attributes",
+                    "description": "Floodlight Sales (transactions) tag attributes",
                     "type": "object",
                     "properties": {
                         "disable_in_debug_mode": {

--- a/tag_manager/authorized_api/src/tags/schema/create/request/facebook_retargeting_pixel_create.json
+++ b/tag_manager/authorized_api/src/tags/schema/create/request/facebook_retargeting_pixel_create.json
@@ -1,6 +1,6 @@
 {
-    "title": "Facebook retargeting pixel tag",
-    "description": "Facebook retargeting pixel tag create request",
+    "title": "Meta pixel tag",
+    "description": "Meta pixel tag create request. (Rebranded from Facebook Retargeting Pixel)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "Facebook retargeting pixel tag attributes",
+                    "description": "Meta pixel tag attributes",
                     "type": "object",
                     "properties": {
                         "disable_in_debug_mode": {

--- a/tag_manager/authorized_api/src/tags/schema/create/request/google_adwords_doubleclick_create.json
+++ b/tag_manager/authorized_api/src/tags/schema/create/request/google_adwords_doubleclick_create.json
@@ -1,10 +1,12 @@
 {
-    "title": "DoubleClick Conversion tag",
+    "title": "DoubleClick Conversion tag [DEPRECATED]",
     "description": "DoubleClick Conversion tag create request",
+    "deprecated": true,
     "type": "object",
     "properties": {
         "data": {
             "title": "JSON:API 1.0 request data",
+            "deprecated": true,
             "type": "object",
             "properties": {
                 "id": {

--- a/tag_manager/authorized_api/src/tags/schema/create/tags_create_request_schema.json
+++ b/tag_manager/authorized_api/src/tags/schema/create/tags_create_request_schema.json
@@ -41,9 +41,6 @@
             "$ref": "request/bing_ads_create.json"
         },
         {
-            "$ref": "request/click_tale_create.json"
-        },
-        {
             "$ref": "request/crazy_egg_create.json"
         },
         {
@@ -60,9 +57,6 @@
         },
         {
             "$ref": "request/doubleclick_floodlight_counter_unique_method_create.json"
-        },
-        {
-            "$ref": "request/google_adwords_doubleclick_create.json"
         },
         {
             "$ref": "request/facebook_retargeting_pixel_create.json"
@@ -114,6 +108,12 @@
         },
         {
             "$ref": "request/heatmaps_create.json"
+        },
+        {
+            "$ref": "request/click_tale_create.json"
+        },
+        {
+            "$ref": "request/google_adwords_doubleclick_create.json"
         }
     ]
 }

--- a/tag_manager/authorized_api/src/tags/schema/edit/request/click_tale_edit.json
+++ b/tag_manager/authorized_api/src/tags/schema/edit/request/click_tale_edit.json
@@ -1,10 +1,12 @@
 {
-    "title": "Clicktale tag",
+    "title": "Clicktale tag [DEPRECATED]",
     "description": "Clicktale tag edit request",
+    "deprecated": true,
     "type": "object",
     "properties": {
         "data": {
             "title": "JSON:API 1.0 request data",
+            "deprecated": true,
             "type": "object",
             "properties": {
                 "id": {

--- a/tag_manager/authorized_api/src/tags/schema/edit/request/doubleclick_floodlight_counter_session_edit.json
+++ b/tag_manager/authorized_api/src/tags/schema/edit/request/doubleclick_floodlight_counter_session_edit.json
@@ -1,6 +1,6 @@
 {
-    "title": "DoubleClick Floodlight Counter (session) tag",
-    "description": "DoubleClick Floodlight Counter (session) tag edit request",
+    "title": "Floodlight Counter (session) tag",
+    "description": "Floodlight Counter (session) tag edit request. (Rebranded from DoubleClick Floodlight Counter)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "DoubleClick Floodlight Counter (session) tag attributes",
+                    "description": "Floodlight Counter (session) tag attributes",
                     "type": "object",
                     "properties": {
                         "disable_in_debug_mode": {

--- a/tag_manager/authorized_api/src/tags/schema/edit/request/doubleclick_floodlight_counter_standard_method_edit.json
+++ b/tag_manager/authorized_api/src/tags/schema/edit/request/doubleclick_floodlight_counter_standard_method_edit.json
@@ -1,6 +1,6 @@
 {
-    "title": "DoubleClick Floodlight Counter (standard_method) tag",
-    "description": "DoubleClick Floodlight Counter (standard_method) tag edit request",
+    "title": "Floodlight Counter (standard_method) tag",
+    "description": "Floodlight Counter (standard_method) tag edit request. (Rebranded from DoubleClick Floodlight Counter)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "DoubleClick Floodlight Counter (standard_method) tag attributes",
+                    "description": "Floodlight Counter (standard_method) tag attributes",
                     "type": "object",
                     "properties": {
                         "disable_in_debug_mode": {

--- a/tag_manager/authorized_api/src/tags/schema/edit/request/doubleclick_floodlight_counter_unique_method_edit.json
+++ b/tag_manager/authorized_api/src/tags/schema/edit/request/doubleclick_floodlight_counter_unique_method_edit.json
@@ -1,6 +1,6 @@
 {
-    "title": "DoubleClick Floodlight Counter (unique_method) tag",
-    "description": "DoubleClick Floodlight Counter (unique_method) tag edit request",
+    "title": "Floodlight Counter (unique_method) tag",
+    "description": "Floodlight Counter (unique_method) tag edit request. (Rebranded from DoubleClick Floodlight Counter)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "DoubleClick Floodlight Counter (unique_method) tag attributes",
+                    "description": "Floodlight Counter (unique_method) tag attributes",
                     "type": "object",
                     "properties": {
                         "disable_in_debug_mode": {

--- a/tag_manager/authorized_api/src/tags/schema/edit/request/doubleclick_floodlight_sales_item_sold_edit.json
+++ b/tag_manager/authorized_api/src/tags/schema/edit/request/doubleclick_floodlight_sales_item_sold_edit.json
@@ -1,6 +1,6 @@
 {
-    "title": "DoubleClick Floodlight Sales (item_sold) tag",
-    "description": "DoubleClick Floodlight Sales (item_sold) tag edit request",
+    "title": "Floodlight Sales (item_sold) tag",
+    "description": "Floodlight Sales (item_sold) tag edit request. (Rebranded from DoubleClick Floodlight Sales)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "DoubleClick Floodlight Sales (item_sold) tag attributes",
+                    "description": "Floodlight Sales (item_sold) tag attributes",
                     "type": "object",
                     "properties": {
                         "disable_in_debug_mode": {

--- a/tag_manager/authorized_api/src/tags/schema/edit/request/doubleclick_floodlight_sales_transactions_edit.json
+++ b/tag_manager/authorized_api/src/tags/schema/edit/request/doubleclick_floodlight_sales_transactions_edit.json
@@ -1,6 +1,6 @@
 {
-    "title": "DoubleClick Floodlight Sales (transactions) tag",
-    "description": "DoubleClick Floodlight Sales (transactions) tag edit request",
+    "title": "Floodlight Sales (transactions) tag",
+    "description": "Floodlight Sales (transactions) tag edit request. (Rebranded from DoubleClick Floodlight Sales)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "DoubleClick Floodlight Sales (transactions) tag attributes",
+                    "description": "Floodlight Sales (transactions) tag attributes",
                     "type": "object",
                     "properties": {
                         "disable_in_debug_mode": {

--- a/tag_manager/authorized_api/src/tags/schema/edit/request/facebook_retargeting_pixel_edit.json
+++ b/tag_manager/authorized_api/src/tags/schema/edit/request/facebook_retargeting_pixel_edit.json
@@ -1,6 +1,6 @@
 {
-    "title": "Facebook retargeting pixel tag",
-    "description": "Facebook retargeting pixel tag edit request",
+    "title": "Meta pixel tag",
+    "description": "Meta pixel tag edit request. (Rebranded from Facebook Retargeting Pixel)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "Facebook retargeting pixel tag attributes",
+                    "description": "Meta pixel tag attributes",
                     "type": "object",
                     "properties": {
                         "disable_in_debug_mode": {

--- a/tag_manager/authorized_api/src/tags/schema/edit/request/google_adwords_doubleclick_edit.json
+++ b/tag_manager/authorized_api/src/tags/schema/edit/request/google_adwords_doubleclick_edit.json
@@ -1,10 +1,12 @@
 {
-    "title": "DoubleClick Conversion tag",
+    "title": "DoubleClick Conversion tag [DEPRECATED]",
     "description": "DoubleClick Conversion tag edit request",
+    "deprecated": true,
     "type": "object",
     "properties": {
         "data": {
             "title": "JSON:API 1.0 request data",
+            "deprecated": true,
             "type": "object",
             "properties": {
                 "id": {

--- a/tag_manager/authorized_api/src/tags/schema/edit/tags_edit_request_schema.json
+++ b/tag_manager/authorized_api/src/tags/schema/edit/tags_edit_request_schema.json
@@ -41,9 +41,6 @@
             "$ref": "request/bing_ads_edit.json"
         },
         {
-            "$ref": "request/click_tale_edit.json"
-        },
-        {
             "$ref": "request/crazy_egg_edit.json"
         },
         {
@@ -60,9 +57,6 @@
         },
         {
             "$ref": "request/doubleclick_floodlight_counter_unique_method_edit.json"
-        },
-        {
-            "$ref": "request/google_adwords_doubleclick_edit.json"
         },
         {
             "$ref": "request/facebook_retargeting_pixel_edit.json"
@@ -114,6 +108,12 @@
         },
         {
             "$ref": "request/heatmaps_edit.json"
+        },
+        {
+            "$ref": "request/click_tale_edit.json"
+        },
+        {
+            "$ref": "request/google_adwords_doubleclick_edit.json"
         }
     ]
 }

--- a/tag_manager/authorized_api/src/tags/schema/get/response/click_tale_get.json
+++ b/tag_manager/authorized_api/src/tags/schema/get/response/click_tale_get.json
@@ -1,10 +1,12 @@
 {
-    "title": "Clicktale tag",
+    "title": "Clicktale tag [DEPRECATED]",
     "description": "Clicktale tag response",
+    "deprecated": true,
     "type": "object",
     "properties": {
         "data": {
             "title": "JSON:API 1.0 response data",
+            "deprecated": true,
             "type": "object",
             "properties": {
                 "id": {

--- a/tag_manager/authorized_api/src/tags/schema/get/response/doubleclick_floodlight_counter_session_get.json
+++ b/tag_manager/authorized_api/src/tags/schema/get/response/doubleclick_floodlight_counter_session_get.json
@@ -1,6 +1,6 @@
 {
-    "title": "DoubleClick Floodlight Counter (session) tag",
-    "description": "DoubleClick Floodlight Counter (session) tag response",
+    "title": "Floodlight Counter (session) tag",
+    "description": "Floodlight Counter (session) tag response. (Rebranded from DoubleClick Floodlight Counter)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "DoubleClick Floodlight Counter (session) tag attributes",
+                    "description": "Floodlight Counter (session) tag attributes",
                     "type": "object",
                     "properties": {
                         "code": {

--- a/tag_manager/authorized_api/src/tags/schema/get/response/doubleclick_floodlight_counter_standard_method_get.json
+++ b/tag_manager/authorized_api/src/tags/schema/get/response/doubleclick_floodlight_counter_standard_method_get.json
@@ -1,6 +1,6 @@
 {
-    "title": "DoubleClick Floodlight Counter (standard_method) tag",
-    "description": "DoubleClick Floodlight Counter (standard_method) tag response",
+    "title": "Floodlight Counter (standard_method) tag",
+    "description": "Floodlight Counter (standard_method) tag response. (Rebranded from DoubleClick Floodlight Counter)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "DoubleClick Floodlight Counter (standard_method) tag attributes",
+                    "description": "Floodlight Counter (standard_method) tag attributes",
                     "type": "object",
                     "properties": {
                         "code": {

--- a/tag_manager/authorized_api/src/tags/schema/get/response/doubleclick_floodlight_counter_unique_method_get.json
+++ b/tag_manager/authorized_api/src/tags/schema/get/response/doubleclick_floodlight_counter_unique_method_get.json
@@ -1,6 +1,6 @@
 {
-    "title": "DoubleClick Floodlight Counter (unique_method) tag",
-    "description": "DoubleClick Floodlight Counter (unique_method) tag response",
+    "title": "Floodlight Counter (unique_method) tag",
+    "description": "Floodlight Counter (unique_method) tag response. (Rebranded from DoubleClick Floodlight Counter)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "DoubleClick Floodlight Counter (unique_method) tag attributes",
+                    "description": "Floodlight Counter (unique_method) tag attributes",
                     "type": "object",
                     "properties": {
                         "code": {

--- a/tag_manager/authorized_api/src/tags/schema/get/response/doubleclick_floodlight_sales_item_sold_get.json
+++ b/tag_manager/authorized_api/src/tags/schema/get/response/doubleclick_floodlight_sales_item_sold_get.json
@@ -1,6 +1,6 @@
 {
-    "title": "DoubleClick Floodlight Sales (item_sold) tag",
-    "description": "DoubleClick Floodlight Sales (item_sold) tag response",
+    "title": "Floodlight Sales (item_sold) tag",
+    "description": "Floodlight Sales (item_sold) tag response. (Rebranded from DoubleClick Floodlight Sales)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "DoubleClick Floodlight Sales (item_sold) tag attributes",
+                    "description": "Floodlight Sales (item_sold) tag attributes",
                     "type": "object",
                     "properties": {
                         "code": {

--- a/tag_manager/authorized_api/src/tags/schema/get/response/doubleclick_floodlight_sales_transactions_get.json
+++ b/tag_manager/authorized_api/src/tags/schema/get/response/doubleclick_floodlight_sales_transactions_get.json
@@ -1,6 +1,6 @@
 {
-    "title": "DoubleClick Floodlight Sales (transactions) tag",
-    "description": "DoubleClick Floodlight Sales (transactions) tag response",
+    "title": "Floodlight Sales (transactions) tag",
+    "description": "Floodlight Sales (transactions) tag response. (Rebranded from DoubleClick Floodlight Sales)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "DoubleClick Floodlight Sales (transactions) tag attributes",
+                    "description": "Floodlight Sales (transactions) tag attributes",
                     "type": "object",
                     "properties": {
                         "code": {

--- a/tag_manager/authorized_api/src/tags/schema/get/response/facebook_retargeting_pixel_get.json
+++ b/tag_manager/authorized_api/src/tags/schema/get/response/facebook_retargeting_pixel_get.json
@@ -1,6 +1,6 @@
 {
-    "title": "Facebook retargeting pixel tag",
-    "description": "Facebook retargeting pixel tag response",
+    "title": "Meta pixel tag",
+    "description": "Meta pixel tag response. (Rebranded from Facebook Retargeting Pixel)",
     "type": "object",
     "properties": {
         "data": {
@@ -14,7 +14,7 @@
                     "$ref": "../../tag_types.json#/definitions/tag_resource_type"
                 },
                 "attributes": {
-                    "description": "Facebook retargeting pixel tag attributes",
+                    "description": "Meta pixel tag attributes",
                     "type": "object",
                     "properties": {
                         "code": {

--- a/tag_manager/authorized_api/src/tags/schema/get/response/google_adwords_doubleclick_get.json
+++ b/tag_manager/authorized_api/src/tags/schema/get/response/google_adwords_doubleclick_get.json
@@ -1,10 +1,12 @@
 {
-    "title": "DoubleClick Conversion tag",
+    "title": "DoubleClick Conversion tag [DEPRECATED]",
     "description": "DoubleClick Conversion tag response",
+    "deprecated": true,
     "type": "object",
     "properties": {
         "data": {
             "title": "JSON:API 1.0 response data",
+            "deprecated": true,
             "type": "object",
             "properties": {
                 "id": {

--- a/tag_manager/authorized_api/src/tags/schema/tag_templates/doubleclick_floodlight/doubleclick_floodlight_base_attributes.json
+++ b/tag_manager/authorized_api/src/tags/schema/tag_templates/doubleclick_floodlight/doubleclick_floodlight_base_attributes.json
@@ -6,12 +6,13 @@
         },
         "template": {
             "$ref": "../../tag_attributes.json#/definitions/template",
+            "description": "Tag template. Despite rebranding the tag name, the template value remained the same due to maintaining backward compatibility.",
             "enum": [
                 "doubleclick_floodlight"
             ]
         },
         "template_options_type_descritpion": {
-            "description": "DoubleClick Floodlight type",
+            "description": "Floodlight type. Despite rebranding the tag name, the template options type value remained the same due to maintaining backward compatibility.",
             "type": "string"
         },
         "template_options_type_sales": {

--- a/tag_manager/authorized_api/src/tags/schema/tag_templates/facebook_retargeting_pixel_attributes.json
+++ b/tag_manager/authorized_api/src/tags/schema/tag_templates/facebook_retargeting_pixel_attributes.json
@@ -6,6 +6,7 @@
         },
         "template": {
             "$ref": "../tag_attributes.json#/definitions/template",
+            "description": "Tag template. Despite rebranding the tag name, the template value remained the same due to maintaining backward compatibility.",
             "enum": [
                 "facebook_retargeting_pixel"
             ]

--- a/tag_manager/authorized_api/src/tags/schema/tag_templates/piwik_base_attributes.json
+++ b/tag_manager/authorized_api/src/tags/schema/tag_templates/piwik_base_attributes.json
@@ -12,7 +12,7 @@
                     "description": "Custom dimension number",
                     "type": "integer",
                     "minimum": 1,
-                    "maximum": 200
+                    "maximum": 400
                 },
                 "value": {
                     "description": "Custom dimension value",
@@ -50,7 +50,7 @@
                 "$ref": "#/definitions/custom_dimensions_item"
             },
             "minItems": 0,
-            "maxItems": 200
+            "maxItems": 400
         },
         "tracker_site_id": {
             "$ref": "../../../common/schema/common_types.json#/definitions/uuid",

--- a/tag_manager/authorized_api/src/tags/schema/tag_templates/piwik_custom_dimension_attributes.json
+++ b/tag_manager/authorized_api/src/tags/schema/tag_templates/piwik_custom_dimension_attributes.json
@@ -17,7 +17,7 @@
                         "$ref": "piwik_base_attributes.json#/definitions/custom_dimensions_item"
                     },
                     "minItems": 1,
-                    "maxItems": 200
+                    "maxItems": 400
                 }
             },
             "additionalProperties": false,

--- a/tag_manager/authorized_api/src/tags/schema/tag_templates/video_html5_attributes.json
+++ b/tag_manager/authorized_api/src/tags/schema/tag_templates/video_html5_attributes.json
@@ -20,7 +20,7 @@
             "description": "Custom dimension id",
             "type": "integer",
             "minimum": 1,
-            "maximum": 200
+            "maximum": 400
         },
         "template_options_element_selectors": {
             "description": "Video element CSS selectors",

--- a/tag_manager/authorized_api/src/triggers.yaml
+++ b/tag_manager/authorized_api/src/triggers.yaml
@@ -1,8 +1,10 @@
 openapi: '3.0.0'
 info:
     title: Tag Manager API
-    description: In order to access those endpoints, you need to **authenticate**. <a href="../../platform/getting_started.html">Here is a guide on how to do it.</a>
     version: '1.0'
+
+security:
+    - BearerAuth: []
 
 servers:
     - url: https://example.piwik.pro
@@ -178,3 +180,6 @@ paths:
                         example:
                             $ref: 'triggers/example/copy/triggers_copy_request_example.json'
 
+components:
+    securitySchemes:
+        $ref: 'common/api/common_security_schemes.json#/components/securitySchemes'

--- a/tag_manager/authorized_api/src/variables.yaml
+++ b/tag_manager/authorized_api/src/variables.yaml
@@ -3,8 +3,6 @@ info:
     title: Tag Manager API
     version: '1.0'
     description: |
-        In order to access those endpoints, you need to **authenticate**. <a href="../../platform/getting_started.html">Here is a guide on how to do it.</a>
-
         # Builtin variables
 
         <details>
@@ -225,3 +223,6 @@ paths:
                         example:
                             $ref: 'variables/example/copy/variables_copy_request_example.json'
 
+components:
+    securitySchemes:
+        $ref: 'common/api/common_security_schemes.json#/components/securitySchemes'

--- a/tag_manager/authorized_api/src/versions.yaml
+++ b/tag_manager/authorized_api/src/versions.yaml
@@ -1,8 +1,10 @@
 openapi: '3.0.0'
 info:
     title: Tag Manager API
-    description: In order to access those endpoints, you need to **authenticate**. <a href="../../platform/getting_started.html">Here is a guide on how to do it.</a>
     version: '1.0'
+
+security:
+    - BearerAuth: []
 
 servers:
     - url: https://example.piwik.pro
@@ -386,3 +388,6 @@ paths:
                                     type: string
                                     format: application/json
 
+components:
+    securitySchemes:
+        $ref: 'common/api/common_security_schemes.json#/components/securitySchemes'


### PR DESCRIPTION
- Rebranded tags to Meta Pixel, Floodlight Sales and Floodlight Counter. Add deprecations.
- Revert click_tale enum case in tag attributes due to behat test fails in api.
- Add additional changes in requests description
- Change text in descriptions
- Additional description changes
- Move deprecation and change info to separate section