### PR TITLE
PPPSYS-40262 fix invalid links in getting started page II

### DIFF
--- a/platform/getting_started.md
+++ b/platform/getting_started.md
@@ -206,14 +206,14 @@ Using API with Postman
 
 [Postman](https://www.getpostman.com/) is a multiplatform GUI application for creating API calls. Piwik PRO allows you to export Swagger documentation and easily import it to Postman. Depending of what you want to work with, you can import the following swagger docs:
 
-* <a href="_static/api/platform_access_control_authorized_api.json" target="_blank">Access control</a>
-* <a href="_static/api/platform_apps_authorized_api.json" target="_blank">Apps</a>
-* <a href="_static/api/platform_audit_log_authorized_api.json" target="_blank">Audit log</a>
-* <a href="_static/api/platform_meta_sites_authorized_api.json" target="_blank">Meta Sites</a>
-* <a href="_static/api/platform_modules_authorized_api.json" target="_blank">Modules</a>
-* <a href="_static/api/platform_tracker_settings_authorized_api.json" target="_blank">Tracker settings</a>
-* <a href="_static/api/platform_users_authorized_api.json" target="_blank">Users</a>
-* <a href="_static/api/platform_user_groups_authorized_api.json" target="_blank">User Groups</a>
+* <a href="/_static/api/platform_access_control_authorized_api.json" target="_blank">Access control</a>
+* <a href="/_static/api/platform_apps_authorized_api.json" target="_blank">Apps</a>
+* <a href="/_static/api/platform_audit_log_authorized_api.json" target="_blank">Audit log</a>
+* <a href="/_static/api/platform_meta_sites_authorized_api.json" target="_blank">Meta Sites</a>
+* <a href="/_static/api/platform_modules_authorized_api.json" target="_blank">Modules</a>
+* <a href="/_static/api/platform_tracker_settings_authorized_api.json" target="_blank">Tracker settings</a>
+* <a href="/_static/api/platform_users_authorized_api.json" target="_blank">Users</a>
+* <a href="/_static/api/platform_user_groups_authorized_api.json" target="_blank">User Groups</a>
 
 To use Postman, follow these steps:
 

--- a/platform/getting_started.md
+++ b/platform/getting_started.md
@@ -206,14 +206,14 @@ Using API with Postman
 
 [Postman](https://www.getpostman.com/) is a multiplatform GUI application for creating API calls. Piwik PRO allows you to export Swagger documentation and easily import it to Postman. Depending of what you want to work with, you can import the following swagger docs:
 
-* <a href="/_static/api/platform_access_control_authorized_api.json" target="_blank">Access control</a>
-* <a href="/_static/api/platform_apps_authorized_api.json" target="_blank">Apps</a>
-* <a href="/_static/api/platform_audit_log_authorized_api.json" target="_blank">Audit log</a>
-* <a href="/_static/api/platform_meta_sites_authorized_api.json" target="_blank">Meta Sites</a>
-* <a href="/_static/api/platform_modules_authorized_api.json" target="_blank">Modules</a>
-* <a href="/_static/api/platform_tracker_settings_authorized_api.json" target="_blank">Tracker settings</a>
-* <a href="/_static/api/platform_users_authorized_api.json" target="_blank">Users</a>
-* <a href="/_static/api/platform_user_groups_authorized_api.json" target="_blank">User Groups</a>
+* <a href="../_static/api/platform_access_control_authorized_api.json" target="_blank">Access control</a>
+* <a href="../_static/api/platform_apps_authorized_api.json" target="_blank">Apps</a>
+* <a href="../_static/api/platform_audit_log_authorized_api.json" target="_blank">Audit log</a>
+* <a href="../_static/api/platform_meta_sites_authorized_api.json" target="_blank">Meta Sites</a>
+* <a href="../_static/api/platform_modules_authorized_api.json" target="_blank">Modules</a>
+* <a href="../_static/api/platform_tracker_settings_authorized_api.json" target="_blank">Tracker settings</a>
+* <a href="../_static/api/platform_users_authorized_api.json" target="_blank">Users</a>
+* <a href="../_static/api/platform_user_groups_authorized_api.json" target="_blank">User Groups</a>
 
 To use Postman, follow these steps:
 


### PR DESCRIPTION
Another one - the previous solution worked locally but `developers.piwik.pro` are always suffixed with `/en/latest` so the absolute path replaced the URL to `developers.piwik.pro/_static/<schema>`  instead of `developers.piwik.pro/en/latest/_static/<schema>` 