### PR TITLE
PPNA-666 Fix order_by in query example

### DIFF
--- a/custom_reports/http_api/definitions/query_request.yaml
+++ b/custom_reports/http_api/definitions/query_request.yaml
@@ -263,9 +263,9 @@ example:
   offset: 0
   limit: 100
   order_by:
-    - - 1
+    - - 0
       - desc
-    - - 2
+    - - 1
       - asc
   format: json
   options:


### PR DESCRIPTION
https://developers.piwik.pro/en/latest/custom_reports/http_api/http_api.html#tag/Queries
order_by	
Array of arrays

Array of sorting directives. Each directive is a 2-element array with 0-based colum index and direction). You can sort on more than one column. By default sorts descending by the first metric in query.
