### PR TITLE
Adds download remote docs script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,21 @@
 FROM python:3.7.4-alpine3.10
 
+RUN adduser -D piwikpro
+
 WORKDIR /app
 
 COPY requirements.local.txt .
 COPY requirements.txt .
+COPY download_remote_docs.py .
+COPY remote_docs_config.json .
 
 RUN python -m pip install --requirement requirements.local.txt && \
     python -m pip install sphinx-autobuild && \
     rm requirements.local.txt && \
     rm requirements.txt
+
+USER piwikpro
+
+RUN python3 download_remote_docs.py
 
 CMD ["sphinx-autobuild", "--host", "0.0.0.0", "--port", "8080", "--ignore", "/app/_static/api/*", "--ignore", "/app/.idea/*", "/app", "/home/python/docs/_build/html"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,15 @@ WORKDIR /app
 
 COPY requirements.local.txt .
 COPY requirements.txt .
-COPY download_remote_docs.py .
-COPY remote_docs_config.json .
 
 RUN python -m pip install --requirement requirements.local.txt && \
     python -m pip install sphinx-autobuild && \
     rm requirements.local.txt && \
     rm requirements.txt
 
-USER piwikpro
+RUN mkdir -p /home/python/docs/_build/html && \
+    chown -R piwikpro:piwikpro /home/python
 
-RUN python3 download_remote_docs.py
+USER piwikpro
 
 CMD ["sphinx-autobuild", "--host", "0.0.0.0", "--port", "8080", "--ignore", "/app/_static/api/*", "--ignore", "/app/.idea/*", "/app", "/home/python/docs/_build/html"]

--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@
 
 When working on this repository, ensure that you start from the right version. There
 are branches corresponding with each released PPMS major-minor version, so you can simply
+
 ```shell script
 git checkout X.Y
 ```
+
 where `X.Y` is PPMS version of your choice, like:
+
 ```shell script
 git checkout 8.2
 ```
+
 will result in checking out docs for PPMS 8.2.x.
 
 ## Running docker container
@@ -38,5 +42,23 @@ docker run \
 You can run it with `docker-compose up`. It uses `docker-compose.yaml` file.
 
 ### Serving generated files
+
 Build files are served by default at http://127.0.0.1:9009/
 Documentation is live (browser updates view each time any file changes).
+
+### Remote docs
+
+If You'd like to fetch docs from a remote repository, please add requested file to the `remote_docs_config.json`.
+Each key of the json file represents a desired directory. Then You need to provide remote `url` and `filename`.
+
+example:
+
+```json
+  "data_collection/web/frameworks/": {"url": "https://raw.githubusercontent.com/PiwikPRO/vue-piwik-pro/master/README.md", "filename": "Piwik_PRO_Library_for_Vue.md"}
+```
+
+To run the script You should have a projects container running (`docker compose up -d`). Then just run the script
+
+```bash
+docker exec -it ppms-publicdocs-ppms_public_docs-1 python3 download_remote_docs.py
+```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Each key of the json file represents a desired directory. Then You need to provi
 example:
 
 ```json
-  "data_collection/web/frameworks/": {"url": "https://raw.githubusercontent.com/PiwikPRO/vue-piwik-pro/master/README.md", "filename": "Piwik_PRO_Library_for_Vue.md"}
+  "Piwik_PRO_Library_for_Vue.md": {"url": "https://raw.githubusercontent.com/PiwikPRO/vue-piwik-pro/master/README.md", "path": "data_collection/web/frameworks/"},
 ```
 
 To run the script You should have a projects container running (`docker compose up -d`). Then just run the script

--- a/download_remote_docs.py
+++ b/download_remote_docs.py
@@ -2,24 +2,19 @@ import requests
 import os
 import json
 
-# Otwórz i przeczytaj plik konfiguracyjny
 with open('remote_docs_config.json', 'r') as f:
     config = json.load(f)
 
-# Dla każdej pary (folder, {url, filename}) w pliku konfiguracyjnym
 for folder, data in config.items():
     url = data['url']
     filename = data['filename']
 
     try:
-        # Pobierz plik .md z danego URL
         response = requests.get(url)
-        response.raise_for_status()  # Rzuć wyjątek, jeśli odpowiedź to błąd HTTP
+        response.raise_for_status()
 
-        # Sprawdź, czy folder istnieje, jeśli nie - utwórz go
         os.makedirs(folder, exist_ok=True)
 
-        # Zapisz pobrany plik .md w odpowiednim folderze pod określoną nazwą pliku
         with open(os.path.join(folder, filename), 'w') as f:
             f.write(response.text)
     except Exception as e:

--- a/download_remote_docs.py
+++ b/download_remote_docs.py
@@ -5,9 +5,9 @@ import json
 with open('remote_docs_config.json', 'r') as f:
     config = json.load(f)
 
-for folder, data in config.items():
+for filename, data in config.items():
     url = data['url']
-    filename = data['filename']
+    folder = data['path']
 
     try:
         response = requests.get(url)

--- a/download_remote_docs.py
+++ b/download_remote_docs.py
@@ -17,5 +17,8 @@ for folder, data in config.items():
 
         with open(os.path.join(folder, filename), 'w') as f:
             f.write(response.text)
+
+        with open(os.path.join(folder, 'index.rst'), 'a') as f:
+            f.write(f'   {filename}\n')
     except Exception as e:
-        print(f"Błąd podczas przetwarzania {folder}/{filename} z {url}: {e}")
+        print(f"Error processing: {folder}/{filename} z {url}: {e}")

--- a/download_remote_docs.py
+++ b/download_remote_docs.py
@@ -1,0 +1,26 @@
+import requests
+import os
+import json
+
+# Otwórz i przeczytaj plik konfiguracyjny
+with open('remote_docs_config.json', 'r') as f:
+    config = json.load(f)
+
+# Dla każdej pary (folder, {url, filename}) w pliku konfiguracyjnym
+for folder, data in config.items():
+    url = data['url']
+    filename = data['filename']
+
+    try:
+        # Pobierz plik .md z danego URL
+        response = requests.get(url)
+        response.raise_for_status()  # Rzuć wyjątek, jeśli odpowiedź to błąd HTTP
+
+        # Sprawdź, czy folder istnieje, jeśli nie - utwórz go
+        os.makedirs(folder, exist_ok=True)
+
+        # Zapisz pobrany plik .md w odpowiednim folderze pod określoną nazwą pliku
+        with open(os.path.join(folder, filename), 'w') as f:
+            f.write(response.text)
+    except Exception as e:
+        print(f"Błąd podczas przetwarzania {folder}/{filename} z {url}: {e}")

--- a/download_remote_docs.py
+++ b/download_remote_docs.py
@@ -18,7 +18,10 @@ for folder, data in config.items():
         with open(os.path.join(folder, filename), 'w') as f:
             f.write(response.text)
 
-        with open(os.path.join(folder, 'index.rst'), 'a') as f:
-            f.write(f'   {filename}\n')
+        index_file_path = os.path.join(folder, 'index.rst')
+        with open(index_file_path, 'a+') as f:  # open the file in append and read mode
+            f.seek(0)  # move the cursor to the beginning of the file
+            if f'   {filename}\n' not in f.read():  # check if the filename already exists in the file
+                f.write(f'   {filename}\n')
     except Exception as e:
         print(f"Error processing: {folder}/{filename} z {url}: {e}")

--- a/remote_docs_config.json
+++ b/remote_docs_config.json
@@ -1,0 +1,3 @@
+{
+  "data_collection/web/frameworks/": {"url": "https://raw.githubusercontent.com/PiwikPRO/vue-piwik-pro/master/README.md", "filename": "Piwik_PRO_Library_for_Vue.md"}
+}

--- a/remote_docs_config.json
+++ b/remote_docs_config.json
@@ -1,3 +1,7 @@
 {
-  "data_collection/web/frameworks/": {"url": "https://raw.githubusercontent.com/PiwikPRO/vue-piwik-pro/master/README.md", "filename": "Piwik_PRO_Library_for_Vue.md"}
+  "Piwik_PRO_Library_for_Vue.md": {"url": "https://raw.githubusercontent.com/PiwikPRO/vue-piwik-pro/master/README.md", "path": "data_collection/web/frameworks/"},
+  "Piwik_PRO_Library_for_Angular.md": {"url": "https://raw.githubusercontent.com/PiwikPRO/ngx-piwik-pro/master/README.md", "path": "data_collection/web/frameworks/"},
+  "Piwik_PRO_Library_for_React.md": {"url": "https://raw.githubusercontent.com/PiwikPRO/react-piwik-pro/master/README.md", "path": "data_collection/web/frameworks/"},
+  "Piwik_PRO_Library_for_NextJS.md": {"url": "https://raw.githubusercontent.com/PiwikPRO/next-piwik-pro/master/README.md", "path": "data_collection/web/frameworks/"},
+  "Piwik_PRO_Plugin_for_Gatsby.md": {"url": "https://raw.githubusercontent.com/PiwikPRO/gatsby-plugin-piwik-pro/master/README.md", "path": "data_collection/web/frameworks/"}
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PyYAML==6.0.1
 docutils==0.17
 jinja2==3.0.0
 sphinx-copybutton==0.5.2
+requests==2.31.0


### PR DESCRIPTION
This feature adds download remote docs functionality to prevent documentation versions mismatch in various repositories.
[Jira](https://piwikpro.atlassian.net/browse/PPI-1025?atlOrigin=eyJpIjoiZThlZWZlM2FkOGRkNGM1YTk3ZjA5NjkzZjE4NjE4MjciLCJwIjoiaiJ9)

I don't think adding script run in `DOCKERFILE` is necessary. Let's discuss that